### PR TITLE
Allow use of bosh director hostname

### DIFF
--- a/pipeline/params.yml
+++ b/pipeline/params.yml
@@ -3,6 +3,9 @@ pcf_opsman_admin_username: user
 pcf_opsman_admin_password: password
 opsman_url: opsman.doma.in
 
+# Set if you use a hostname for bosh director (for PCF foundation)
+pcf_bosh_director_hostname:
+
 # Elastic Runtime Domain
 pcf_ert_domain: doma.in
 

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -55,6 +55,7 @@ jobs:
     file: pcf-prometheus-git/pipeline/tasks/create-uaa-creds.yml
     params:
       opsman_url: {{opsman_url}}
+      pcf_bosh_director_hostname: {{pcf_bosh_director_hostname}}
       pcf_ert_domain: {{pcf_ert_domain}}
       pcf_opsman_admin_username: {{pcf_opsman_admin_username}}
       pcf_opsman_admin_password: {{pcf_opsman_admin_password}}
@@ -98,6 +99,7 @@ jobs:
     file: pcf-prometheus-git/pipeline/tasks/deploy.yml
     params:
       opsman_url: {{opsman_url}}
+      pcf_bosh_director_hostname: {{pcf_bosh_director_hostname}}
       prometheus_bosh_client: {{prometheus_bosh_client}}
       prometheus_bosh_secret: {{prometheus_bosh_secret}}
       prometheus_firehose_client: {{prometheus_firehose_client}}

--- a/pipeline/tasks/create-uaa-creds.yml
+++ b/pipeline/tasks/create-uaa-creds.yml
@@ -11,6 +11,7 @@ inputs:
 
 params:
   pcf_ert_domain:
+  pcf_bosh_director_hostname:
   pcf_opsman_admin_username:
   pcf_opsman_admin_password:
   pcf_sys_domain:

--- a/pipeline/tasks/deploy.sh
+++ b/pipeline/tasks/deploy.sh
@@ -5,8 +5,14 @@ CURL="om --target https://${opsman_url} -k \
   --password $pcf_opsman_admin_password \
   curl"
 
+if [ -z "$pcf_bosh_director_hostname" ]; then
+  director_uri=$(cat om-bosh-creds/director_ip)
+else
+  director_uri=${pcf_bosh_director_hostname}
+fi
+
 if [[ -s om-bosh-creds/bosh-ca.pem ]]; then
-  bosh -n --ca-cert om-bosh-creds/bosh-ca.pem target `cat om-bosh-creds/director_ip`
+  bosh -n --ca-cert om-bosh-creds/bosh-ca.pem target ${director_uri}
 else
   bosh -n target `cat om-bosh-creds/director_ip`
 fi

--- a/pipeline/tasks/etc/local.yml
+++ b/pipeline/tasks/etc/local.yml
@@ -32,10 +32,10 @@ prometheus:
 bosh_exporter:
   bosh:
     uaa:
-      url: https://$(cat om-bosh-creds/director_ip):8443
+      url: https://$(if [ -z "$pcf_bosh_director_hostname" ]; then cat pcf-bosh-creds/director_ip; else echo $pcf_bosh_director_hostname; fi):8443
       client_id: ${prometheus_bosh_client}
       client_secret: ${prometheus_bosh_secret}
-    url: https://$(cat om-bosh-creds/director_ip)
+    url: https://$(if [ -z "$pcf_bosh_director_hostname" ]; then cat pcf-bosh-creds/director_ip; else echo $pcf_bosh_director_hostname; fi)
     ca_cert: |
 $(cat om-bosh-creds/bosh-ca.pem | awk '{printf "      %s\n", $0}')
 


### PR DESCRIPTION
The IP is unusable for bosh UAA when using a director hostname. This will allow someone to specify the bosh director hostname if it is in use, and use that instead of the director IP.