### PR TITLE
Allow use of external deployment director

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -2,7 +2,7 @@
 
 This pipeline sets up a Prometheus monitoring environment for PCF.
 
-It can target an ops manager BOSH director or a standalone one.
+It can target an ops manager BOSH director or a standalone bosh director to monitor/deploy to.
 
 ## Jobs
 
@@ -20,32 +20,34 @@ It can target an ops manager BOSH director or a standalone one.
 
 ## Parameters:
 
-
   - `github_token`: A github token
   - `pcf_sys_domain`: PCF System Domain
   - `prometheus_bosh_client`: prometheus BOSH UAA client name
   - `prometheus_bosh_secret`: Secret for the prometheus BOSH UAA client
   - `prometheus_firehose_client`: Prometheus CF UAA client name
   - `prometheus_firehose_secret`: Secret for the prometheus CF UAA client
-  - `prometheus_cf_username`: Username for the prometheus CF
-  - `prometheus_cf_password`: Password for the prometheus CF user
+  - `prometheus_cf_client`: Username for the prometheus CF
+  - `prometheus_cf_secret`: Password for the prometheus CF user
   - `deploy_azs`: Deployment AZs (Array)
   - `deploy_network`: Deployment Network
   - `deploy_vm_password`: SHA of the VM Password
   - `deploy_nginx_ip`: IP for front end server
   - `bosh_creds_source`: Source of BOSH credentials (`opsman` or `manual`)
 
-If you are using ops manager
+Define what foundation to monitor and where to deploy prometheus 
+  - `pcf_bosh_creds_source`: Use either `opsman` or `manual` to define where the monitored foundation exists
+  - `deploy_bosh_creds_source`: Use either `opsman` or `manual` to define where prometheus will be deployed
+
+Ops Man:
   - `pcf_opsman_admin_username`: Ops Manager admin username
   - `pcf_opsman_admin_password`: Ops Manager admin password
   - `opsman_url`: Ops Manager URL
   - `pcf_ert_domain`: Main CF Domain
 
-If you are providing credentials manually:
-
+Manual:
  - `bosh_username`: BOSH Director username
  - `bosh_password`: BOSH Director password
- -  `director_ip`: BOSH Director IP
+ - `director_ip`: BOSH Director IP
  - `bosh_ca`: BOSH CA certificate (if any)
  - `nats_machines`: NATS Machines
  - `nats_username`: NATS Username

--- a/pipeline/params.yml
+++ b/pipeline/params.yml
@@ -15,8 +15,8 @@ prometheus_bosh_client: prometheus-bosh
 prometheus_bosh_secret: prometheus-client-secret
 prometheus_firehose_client: prometheus-firehose
 prometheus_firehose_secret: prometheus-client-secret
-prometheus_cf_username: prometheus-cf
-prometheus_cf_password: prometheus-client-secret
+prometheus_cf_client: prometheus-cf
+prometheus_cf_secret: prometheus-client-secret
 prometheus_cf_deployment_name: cf
 
 deploy_azs: "[az1, az2]"

--- a/pipeline/params.yml
+++ b/pipeline/params.yml
@@ -26,7 +26,8 @@ deploy_nginx_ip: 1.1.1.1
 deploy_vm_type_micro: micro
 deploy_vm_type_small: small
 
-bosh_creds_source: opsman
+pcf_bosh_creds_source: opsman
+deploy_bosh_creds_source: opsman
 
 # Fill in if you use `bosh_creds_source: manual`
 bosh_username: ""

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -31,10 +31,24 @@ resources:
     user: cloudfoundry-community
     repository: node-exporter-boshrelease
     access_token: {{github_token}}
-- name: om-bosh-creds
+- name: pcf-bosh-creds
   type: bosh-creds
   source:
-    creds_source: {{bosh_creds_source}}
+    creds_source: {{pcf_bosh_creds_source}}
+    # Fill in for Ops manager credentials
+    pcf_ert_domain: {{pcf_ert_domain}}
+    pcf_opsman_admin_username: {{pcf_opsman_admin_username}}
+    pcf_opsman_admin_password: {{pcf_opsman_admin_password}}
+    opsman_url: {{opsman_url}}
+    # Or manual credentials
+    bosh_username: {{bosh_username}}
+    bosh_password: {{bosh_password}}
+    director_ip: {{director_ip}}
+    bosh_ca: {{bosh_ca}}
+- name: deploy-bosh-creds
+  type: bosh-creds
+  source:
+    creds_source: {{deploy_bosh_creds_source}}
     # Fill in for Ops manager credentials
     pcf_ert_domain: {{pcf_ert_domain}}
     pcf_opsman_admin_username: {{pcf_opsman_admin_username}}
@@ -74,7 +88,8 @@ jobs:
     - get: prometheus-release
     - get: prometheus-custom-release
     - get: node-exporter-release
-    - get: om-bosh-creds
+    - get: pcf-bosh-creds
+    - get: deploy-bosh-creds
   - task: upload-release
     file: pcf-prometheus-git/pipeline/tasks/upload-release.yml
 
@@ -82,7 +97,7 @@ jobs:
   plan:
   - aggregate:
     - get: pcf-prometheus-git
-    - get: om-bosh-creds
+    - get: pcf-bosh-creds
       passed: [upload-release]
   - task: install-node-exporter
     file: pcf-prometheus-git/pipeline/tasks/install-node-exporter.yml
@@ -92,8 +107,10 @@ jobs:
   - aggregate:
     - get: pcf-prometheus-git
       trigger: true
-    - get: om-bosh-creds
+    - get: pcf-bosh-creds
       passed: [install-node-exporter]
+    - get: deploy-bosh-creds
+      passed: [upload-release]
   - task: deploy
     file: pcf-prometheus-git/pipeline/tasks/deploy.yml
     params:

--- a/pipeline/tasks/deploy.sh
+++ b/pipeline/tasks/deploy.sh
@@ -5,14 +5,14 @@ CURL="om --target https://${opsman_url} -k \
   --password $pcf_opsman_admin_password \
   curl"
 
-if [[ -s om-bosh-creds/bosh-ca.pem ]]; then
-  bosh -n --ca-cert om-bosh-creds/bosh-ca.pem target `cat om-bosh-creds/director_ip`
+if [[ -s deploy-bosh-creds/bosh-ca.pem ]]; then
+  bosh -n --ca-cert deploy-bosh-creds/bosh-ca.pem target `cat deploy-bosh-creds/director_ip`
 else
-  bosh -n target `cat om-bosh-creds/director_ip`
+  bosh -n target `cat deploy-bosh-creds/director_ip`
 fi
 
-BOSH_USERNAME=$(cat om-bosh-creds/bosh-username)
-BOSH_PASSWORD=$(cat om-bosh-creds/bosh-pass)
+BOSH_USERNAME=$(cat deploy-bosh-creds/bosh-username)
+BOSH_PASSWORD=$(cat deploy-bosh-creds/bosh-pass)
 
 echo "Logging in to BOSH..."
 bosh login <<EOF 1>/dev/null

--- a/pipeline/tasks/deploy.sh
+++ b/pipeline/tasks/deploy.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 set -e
-CURL="om --target https://${opsman_url} -k \
-  --username $pcf_opsman_admin_username \
-  --password $pcf_opsman_admin_password \
-  curl"
 
 if [[ -s deploy-bosh-creds/bosh-ca.pem ]]; then
   bosh -n --ca-cert deploy-bosh-creds/bosh-ca.pem target `cat deploy-bosh-creds/director_ip`

--- a/pipeline/tasks/deploy.yml
+++ b/pipeline/tasks/deploy.yml
@@ -7,7 +7,8 @@ image_resource:
     repository: dlapiduz/c0-worker
 
 inputs:
-- name: om-bosh-creds
+- name: pcf-bosh-creds
+- name: deploy-bosh-creds
 - name: pcf-prometheus-git
 
 params:

--- a/pipeline/tasks/etc/local.yml
+++ b/pipeline/tasks/etc/local.yml
@@ -32,12 +32,12 @@ prometheus:
 bosh_exporter:
   bosh:
     uaa:
-      url: https://$(cat om-bosh-creds/director_ip):8443
+      url: https://$(cat pcf-bosh-creds/director_ip):8443
       client_id: ${prometheus_bosh_client}
       client_secret: ${prometheus_bosh_secret}
-    url: https://$(cat om-bosh-creds/director_ip)
+    url: https://$(cat pcf-bosh-creds/director_ip)
     ca_cert: |
-$(cat om-bosh-creds/bosh-ca.pem | awk '{printf "      %s\n", $0}')
+$(cat pcf-bosh-creds/bosh-ca.pem | awk '{printf "      %s\n", $0}')
 
 firehose_exporter:
   uaa:

--- a/pipeline/tasks/install-node-exporter.sh
+++ b/pipeline/tasks/install-node-exporter.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -e
 
-if [[ -s om-bosh-creds/bosh-ca.pem ]]; then
-  bosh -n --ca-cert om-bosh-creds/bosh-ca.pem target `cat om-bosh-creds/director_ip`
+if [[ -s pcf-bosh-creds/bosh-ca.pem ]]; then
+  bosh -n --ca-cert pcf-bosh-creds/bosh-ca.pem target `cat pcf-bosh-creds/director_ip`
 else
-  bosh -n target `cat om-bosh-creds/director_ip`
+  bosh -n target `cat pcf-bosh-creds/director_ip`
 fi
 
-BOSH_USERNAME=$(cat om-bosh-creds/bosh-username)
-BOSH_PASSWORD=$(cat om-bosh-creds/bosh-pass)
+BOSH_USERNAME=$(cat pcf-bosh-creds/bosh-username)
+BOSH_PASSWORD=$(cat pcf-bosh-creds/bosh-pass)
 
 echo "Logging in to BOSH..."
 bosh login <<EOF 1>/dev/null

--- a/pipeline/tasks/install-node-exporter.yml
+++ b/pipeline/tasks/install-node-exporter.yml
@@ -8,7 +8,7 @@ image_resource:
 
 inputs:
 - name: pcf-prometheus-git
-- name: om-bosh-creds
+- name: pcf-bosh-creds
 
 run:
   path: pcf-prometheus-git/pipeline/tasks/install-node-exporter.sh

--- a/pipeline/tasks/upload-release.sh
+++ b/pipeline/tasks/upload-release.sh
@@ -1,26 +1,34 @@
 #!/bin/bash
 set -e
 
-if [[ -s om-bosh-creds/bosh-ca.pem ]]; then
-  bosh -n --ca-cert om-bosh-creds/bosh-ca.pem target `cat om-bosh-creds/director_ip`
-else
-  bosh -n target `cat om-bosh-creds/director_ip`
-fi
+function login_to_director() {
+  CREDS=$1
 
-BOSH_USERNAME=$(cat om-bosh-creds/bosh-username)
-BOSH_PASSWORD=$(cat om-bosh-creds/bosh-pass)
+  if [[ -s $CREDS/bosh-ca.pem ]]; then
+    bosh -n --ca-cert $CREDS/bosh-ca.pem target `cat $CREDS/director_ip`
+  else
+    bosh -n target `cat $CREDS/director_ip`
+  fi
 
-echo "Logging in to BOSH..."
-bosh login <<EOF 1>/dev/null
-$BOSH_USERNAME
-$BOSH_PASSWORD
+  BOSH_USERNAME=$(cat $CREDS/bosh-username)
+  BOSH_PASSWORD=$(cat $CREDS/bosh-pass)
+
+  echo "Logging in to BOSH..."
+  bosh login <<EOF 1>/dev/null
+  $BOSH_USERNAME
+  $BOSH_PASSWORD
 EOF
+}
+
+login_to_director pcf-bosh-creds
+
+echo "Uploading Prometheus Customizations Release..."
+bosh -n upload release prometheus-custom-release/prometheus-custom-*.tgz
+
+login_to_director deploy-bosh-creds
 
 echo "Uploading Prometheus Release..."
 bosh -n upload release prometheus-release/prometheus-*.tgz
 
 echo "Uploading Node exporter Release..."
 bosh -n upload release node-exporter-release/node-exporter-*.tgz
-
-echo "Uploading Prometheus Customizations Release..."
-bosh -n upload release prometheus-custom-release/prometheus-custom-*.tgz

--- a/pipeline/tasks/upload-release.sh
+++ b/pipeline/tasks/upload-release.sh
@@ -22,13 +22,13 @@ EOF
 
 login_to_director pcf-bosh-creds
 
-echo "Uploading Prometheus Customizations Release..."
-bosh -n upload release prometheus-custom-release/prometheus-custom-*.tgz
+echo "Uploading Node exporter Release..."
+bosh -n upload release node-exporter-release/node-exporter-*.tgz
 
 login_to_director deploy-bosh-creds
 
 echo "Uploading Prometheus Release..."
 bosh -n upload release prometheus-release/prometheus-*.tgz
 
-echo "Uploading Node exporter Release..."
-bosh -n upload release node-exporter-release/node-exporter-*.tgz
+echo "Uploading Prometheus Customizations Release..."
+bosh -n upload release prometheus-custom-release/prometheus-custom-*.tgz

--- a/pipeline/tasks/upload-release.yml
+++ b/pipeline/tasks/upload-release.yml
@@ -8,7 +8,8 @@ image_resource:
 
 inputs:
 - name: pcf-prometheus-git
-- name: om-bosh-creds
+- name: pcf-bosh-creds
+- name: deploy-bosh-creds
 - name: prometheus-release
 - name: prometheus-custom-release
 - name: node-exporter-release


### PR DESCRIPTION
Allow the use of a deployment bosh director that doesn't live alongside the PCF foundation bosh director. This can be set using the `deploy_bosh_creds_source` variable in `params.yml`. You can deploy to the same foundation by using `opsman` or use `manual` and define an external bosh director and set the credentials for it in `params.yml`.