### PR TITLE
comment out mysqld_exporter config

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -283,14 +283,14 @@ instance_groups:
         metrics:
           environment: cf
         skip_ssl_verify: true
-  - name: mysqld_exporter
-    release: prometheus
-    properties:
-      mysqld_exporter:
-        mysql:
-          address: ((mysqld_exporter.mysql.address))
-          username: ((mysqld_exporter.mysql.username))
-          password: ((mysqld_exporter.mysql.password))
+  #- name: mysqld_exporter
+  #  release: prometheus
+  #  properties:
+  #    mysqld_exporter:
+  #      mysql:
+  #        address: ((mysqld_exporter.mysql.address))
+  #        username: ((mysqld_exporter.mysql.username))
+  #        password: ((mysqld_exporter.mysql.password))
   - name: firehose_exporter
     release: prometheus
     properties:


### PR DESCRIPTION
The `mysqld_exporter` returns an error when running the pipeline out of the box with no changes. This should remedy the error thrown by not having these values available.